### PR TITLE
Add repository tag to yaml

### DIFF
--- a/parallel_docker_build/tools.py
+++ b/parallel_docker_build/tools.py
@@ -42,10 +42,6 @@ def get_high_level_docker_api():
     return docker.from_env()
 
 
-def get_low_level_docker_api():
-    return docker.APIClient()
-
-
 def parse_stream(out) -> List[AnyStr]:
     data = json.loads(out)
     if "error" in data:
@@ -72,7 +68,7 @@ def do_build(
     dockerfile = _absolute_file(dockerfile)
     context = _absolute_dir(context)
     do_print(f"Building {dockerfile} from context {context}", name=name, quiet=quiet)
-    api = get_low_level_docker_api()
+    api = get_high_level_docker_api()
     name = full_name if name is None else f"{name}|{full_name}"
     if not str(dockerfile).startswith(str(context)):
         raise FileNotFoundError(

--- a/parallel_docker_build/tools.py
+++ b/parallel_docker_build/tools.py
@@ -6,6 +6,7 @@ import yaml
 from pathlib import Path
 from typing import Iterable, Union, List, AnyStr
 import docker
+from docker.utils import kwargs_from_env
 
 MAX_NUM_WORKERS = int(multiprocessing.cpu_count() // 2)
 WORKFLOW_SCHEMA_PATH = Path(__file__).parent / "workflow-schema.yaml"
@@ -42,6 +43,11 @@ def get_high_level_docker_api():
     return docker.from_env()
 
 
+def get_low_level_docker_api():
+    kwargs = kwargs_from_env()
+    return docker.APIClient(**kwargs)
+
+
 def parse_stream(out) -> List[AnyStr]:
     data = json.loads(out)
     if "error" in data:
@@ -68,7 +74,7 @@ def do_build(
     dockerfile = _absolute_file(dockerfile)
     context = _absolute_dir(context)
     do_print(f"Building {dockerfile} from context {context}", name=name, quiet=quiet)
-    api = get_high_level_docker_api()
+    api = get_low_level_docker_api()
     name = full_name if name is None else f"{name}|{full_name}"
     if not str(dockerfile).startswith(str(context)):
         raise FileNotFoundError(

--- a/parallel_docker_build/tools.py
+++ b/parallel_docker_build/tools.py
@@ -119,7 +119,7 @@ def make_image(
     rebuild: bool = False,
     quiet: bool = False,
     name: str = None,
-    repo: str = None,
+    registry: str = None,
 ) -> None:
     # Handle paths
     dockerfile = _absolute_file(dockerfile)
@@ -167,8 +167,8 @@ def make_image(
     )
     # Push it
     if push:
-        full_repo_name = f"{repo}/{full_name}" if repo is not None else full_name
-        do_push(full_repo_name, tags=["latest"], quiet=quiet, name=name)
+        full_reg_name = f"{registry}/{full_name}" if registry is not None else full_name
+        do_push(full_reg_name, tags=["latest"], quiet=quiet, name=name)
 
 
 def make_images(
@@ -181,7 +181,7 @@ def make_images(
     rebuild: bool = False,
     quiet: bool = False,
     name: str = None,
-    repo: str = None,
+    registry: str = None,
 ) -> None:
     if len(dockerfiles) == 1 or max_num_workers == 1:
         for dockerfile in dockerfiles:
@@ -194,7 +194,7 @@ def make_images(
                 push=push,
                 quiet=quiet,
                 name=name,
-                repo=repo,
+                registry=registry,
             )
     else:
         results = []
@@ -212,7 +212,7 @@ def make_images(
                             push=push,
                             quiet=quiet,
                             name=name,
-                            repo=repo,
+                            registry=registry,
                         ),
                     )
                 )
@@ -277,7 +277,7 @@ def validate_workflow_yaml(workflow: Union[Path, dict]) -> dict:
     validated.setdefault("max_num_workers", 1)
     validated.setdefault("cross_platform", False)
     validated.setdefault("push", False)
-    validated.setdefault("repository", None)
+    validated.setdefault("registry", None)
     for stage in validated["stages"]:
         stage.setdefault("context", ".")
     return validated
@@ -299,6 +299,6 @@ def run_workflow(workflow: Path, rebuild: bool = False, quiet: bool = False) -> 
             rebuild=rebuild,
             quiet=quiet,
             name=name,
-            repo=data["repository"],
+            registry=data["registry"],
         )
     do_print(f"Workflow complete: {workflow}")

--- a/parallel_docker_build/tools.py
+++ b/parallel_docker_build/tools.py
@@ -119,6 +119,7 @@ def make_image(
     rebuild: bool = False,
     quiet: bool = False,
     name: str = None,
+    repo: str = None,
 ) -> None:
     # Handle paths
     dockerfile = _absolute_file(dockerfile)
@@ -166,7 +167,8 @@ def make_image(
     )
     # Push it
     if push:
-        do_push(full_name, tags=["latest"], quiet=quiet, name=name)
+        full_repo_name = f"{repo}/{full_name}" if repo is not None else full_name
+        do_push(full_repo_name, tags=["latest"], quiet=quiet, name=name)
 
 
 def make_images(
@@ -179,6 +181,7 @@ def make_images(
     rebuild: bool = False,
     quiet: bool = False,
     name: str = None,
+    repo: str = None,
 ) -> None:
     if len(dockerfiles) == 1 or max_num_workers == 1:
         for dockerfile in dockerfiles:
@@ -191,6 +194,7 @@ def make_images(
                 push=push,
                 quiet=quiet,
                 name=name,
+                repo=repo,
             )
     else:
         results = []
@@ -208,6 +212,7 @@ def make_images(
                             push=push,
                             quiet=quiet,
                             name=name,
+                            repo=repo,
                         ),
                     )
                 )
@@ -272,6 +277,7 @@ def validate_workflow_yaml(workflow: Union[Path, dict]) -> dict:
     validated.setdefault("max_num_workers", 1)
     validated.setdefault("cross_platform", False)
     validated.setdefault("push", False)
+    validated.setdefault("repository", None)
     for stage in validated["stages"]:
         stage.setdefault("context", ".")
     return validated
@@ -293,5 +299,6 @@ def run_workflow(workflow: Path, rebuild: bool = False, quiet: bool = False) -> 
             rebuild=rebuild,
             quiet=quiet,
             name=name,
+            repo=data["repository"],
         )
     do_print(f"Workflow complete: {workflow}")

--- a/parallel_docker_build/workflow-schema.yaml
+++ b/parallel_docker_build/workflow-schema.yaml
@@ -1,7 +1,7 @@
 # Organization for docker images. i.e. <Organization>/<image_name>
 organization: str()
-# The url of the repository: Default None (dockerhub.com)
-repository: str(required=False)
+# The url of the registry: Default None (dockerhub.com)
+registry: str(required=False)
 # Max number of parallel build workers (multiprocessing pool size). Default: 1
 max_num_workers: int(min=1, required=False)
 # Allow cross platform (x86 vs aarch64) building. Default: False

--- a/parallel_docker_build/workflow-schema.yaml
+++ b/parallel_docker_build/workflow-schema.yaml
@@ -1,5 +1,7 @@
 # Organization for docker images. i.e. <Organization>/<image_name>
 organization: str()
+# The url of the repository: Default None (dockerhub.com)
+repository: str(required=False)
 # Max number of parallel build workers (multiprocessing pool size). Default: 1
 max_num_workers: int(min=1, required=False)
 # Allow cross platform (x86 vs aarch64) building. Default: False


### PR DESCRIPTION
One doesn't always want to push to `dockerhub.com`. This adds a tag to the `workflow.yaml` file, that allows to define an alternative registry url.

This is possible with the current setup by setting:

```yaml
organization: my-custom-registry.com/my-project/my-image
```

However this will make the respective image appear as such locally as well, while often one likes to have `my-project/my-image` as the local name (I think that is the expected behavior?).

`repository` is not required and everything behaves as before if the tag is not used. It is also only used for pushing dockers, nowhere else.