### PR TITLE
Enable reading from stdin

### DIFF
--- a/parallel_docker_build/cli.py
+++ b/parallel_docker_build/cli.py
@@ -31,7 +31,7 @@ def parse_cmd_line_args():
     # Specify a yaml workflow
     workflow_parser.add_argument(
         "workflow",
-        type=str,
+        type=argparse.FileType("r"),
         help="Path to workflow yaml file image filenames(s).",
     )
 

--- a/parallel_docker_build/tools.py
+++ b/parallel_docker_build/tools.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import Iterable, Union, List, AnyStr
 import docker
 from docker.utils import kwargs_from_env
+import sys
 
 MAX_NUM_WORKERS = int(multiprocessing.cpu_count() // 2)
 WORKFLOW_SCHEMA_PATH = Path(__file__).parent / "workflow-schema.yaml"
@@ -259,7 +260,10 @@ def validate_workflow_yaml(workflow: Union[Path, dict]) -> dict:
     """
     # Load
     if isinstance(workflow, (Path, str)):
-        data = yamale.make_data(path=_absolute_file(workflow))
+        if workflow == "-":
+            data = yamale.make_data(content=sys.stdin.read())
+        else:
+            data = yamale.make_data(path=_absolute_file(workflow))
     elif isinstance(workflow, dict):
         data = yamale.make_data(content=yaml.dump(workflow))
     else:

--- a/parallel_docker_build/tools.py
+++ b/parallel_docker_build/tools.py
@@ -42,10 +42,6 @@ def get_high_level_docker_api():
     return docker.from_env()
 
 
-def get_low_level_docker_api():
-    return docker.APIClient()
-
-
 def parse_stream(out) -> List[AnyStr]:
     data = json.loads(out)
     if "error" in data:
@@ -72,7 +68,7 @@ def do_build(
     dockerfile = _absolute_file(dockerfile)
     context = _absolute_dir(context)
     do_print(f"Building {dockerfile} from context {context}", name=name, quiet=quiet)
-    api = get_low_level_docker_api()
+    api = get_high_level_docker_api()
     name = full_name if name is None else f"{name}|{full_name}"
     if not str(dockerfile).startswith(str(context)):
         raise FileNotFoundError(

--- a/parallel_docker_build/tools.py
+++ b/parallel_docker_build/tools.py
@@ -44,8 +44,7 @@ def get_high_level_docker_api():
 
 
 def get_low_level_docker_api():
-    kwargs = kwargs_from_env()
-    return docker.APIClient(**kwargs)
+    return docker.APIClient(**kwargs_from_env())
 
 
 def parse_stream(out) -> List[AnyStr]:

--- a/parallel_docker_build/tools.py
+++ b/parallel_docker_build/tools.py
@@ -6,6 +6,7 @@ import yaml
 from pathlib import Path
 from typing import Iterable, Union, List, AnyStr
 import docker
+from docker.utils import kwargs_from_env
 
 MAX_NUM_WORKERS = int(multiprocessing.cpu_count() // 2)
 WORKFLOW_SCHEMA_PATH = Path(__file__).parent / "workflow-schema.yaml"
@@ -42,6 +43,11 @@ def get_high_level_docker_api():
     return docker.from_env()
 
 
+def get_low_level_docker_api():
+    kwargs = kwargs_from_env()
+    return docker.APIClient(**kwargs)
+
+
 def parse_stream(out) -> List[AnyStr]:
     data = json.loads(out)
     if "error" in data:
@@ -68,7 +74,7 @@ def do_build(
     dockerfile = _absolute_file(dockerfile)
     context = _absolute_dir(context)
     do_print(f"Building {dockerfile} from context {context}", name=name, quiet=quiet)
-    api = get_high_level_docker_api()
+    api = get_low_level_docker_api()
     name = full_name if name is None else f"{name}|{full_name}"
     if not str(dockerfile).startswith(str(context)):
         raise FileNotFoundError(

--- a/parallel_docker_build/tools.py
+++ b/parallel_docker_build/tools.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import Iterable, Union, List, AnyStr
 import docker
 from docker.utils import kwargs_from_env
+import sys
 
 MAX_NUM_WORKERS = int(multiprocessing.cpu_count() // 2)
 WORKFLOW_SCHEMA_PATH = Path(__file__).parent / "workflow-schema.yaml"
@@ -260,7 +261,10 @@ def validate_workflow_yaml(workflow: Union[Path, dict]) -> dict:
     """
     # Load
     if isinstance(workflow, (Path, str)):
-        data = yamale.make_data(path=_absolute_file(workflow))
+        if workflow == "-":
+            data = yamale.make_data(content=sys.stdin.read())
+        else:
+            data = yamale.make_data(path=_absolute_file(workflow))
     elif isinstance(workflow, dict):
         data = yamale.make_data(content=yaml.dump(workflow))
     else:

--- a/parallel_docker_build/tools.py
+++ b/parallel_docker_build/tools.py
@@ -4,7 +4,7 @@ import multiprocessing
 import yamale
 import yaml
 from pathlib import Path
-from typing import Iterable, Union, List, AnyStr
+from typing import Iterable, Union, List, AnyStr, IO
 import docker
 from docker.utils import kwargs_from_env
 import sys
@@ -246,13 +246,13 @@ def get_dockerfiles_from_paths(
     return dockerfiles
 
 
-def validate_workflow_yaml(workflow: Union[Path, dict]) -> dict:
+def validate_workflow_yaml(workflow: Union[IO, dict, str]) -> dict:
     """Validate workflow yaml file
 
     Parameters
     ----------
-    workflow : Union[Path, dict]
-        Workflow yaml path or loaded dictionary.
+    workflow : Union[IO, dict, str]
+        Workflow yaml file-object/stream, dictionary or string with yaml data.
 
     Returns
     -------
@@ -260,15 +260,13 @@ def validate_workflow_yaml(workflow: Union[Path, dict]) -> dict:
         Validated workflow
     """
     # Load
-    if isinstance(workflow, (Path, str)):
-        if workflow == "-":
-            data = yamale.make_data(content=sys.stdin.read())
-        else:
-            data = yamale.make_data(path=_absolute_file(workflow))
-    elif isinstance(workflow, dict):
-        data = yamale.make_data(content=yaml.dump(workflow))
+    if isinstance(workflow, dict):
+        content = yaml.dump(workflow)
+    elif hasattr(workflow, "read"):
+        content = workflow.read()
     else:
-        raise ValueError(f"The workflow is not supported: {workflow}")
+        content = workflow
+    data = yamale.make_data(content=content)
     schema = yamale.make_schema(WORKFLOW_SCHEMA_PATH)
     yamale.validate(schema, data)
     validated = data[0][0]
@@ -281,7 +279,7 @@ def validate_workflow_yaml(workflow: Union[Path, dict]) -> dict:
     return validated
 
 
-def run_workflow(workflow: Path, rebuild: bool = False, quiet: bool = False) -> None:
+def run_workflow(workflow: IO, rebuild: bool = False, quiet: bool = False) -> None:
     do_print(f"Loading: {workflow}")
     data = validate_workflow_yaml(workflow)
     for i, stage in enumerate(data["stages"]):

--- a/parallel_docker_build/tools.py
+++ b/parallel_docker_build/tools.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import Iterable, Union, List, AnyStr, IO
 import docker
 from docker.utils import kwargs_from_env
-import sys
+
 
 MAX_NUM_WORKERS = int(multiprocessing.cpu_count() // 2)
 WORKFLOW_SCHEMA_PATH = Path(__file__).parent / "workflow-schema.yaml"


### PR DESCRIPTION
This will make it possible to read yaml files from stdin through passing in `-` as the workflow filename. Quite useful to overwrite defaults with `yq`:

```bash
yq .push=True workflow.yaml | parallel-docker-build workflow -
```