### PR TITLE
Add tag

### DIFF
--- a/parallel_docker_build/cli.py
+++ b/parallel_docker_build/cli.py
@@ -93,7 +93,9 @@ def main():
     args = parse_cmd_line_args()
     if args.mode == "workflow":
         tools.run_workflow(
-            args.workflow, rebuild=args.rebuild, quiet=args.quiet,
+            args.workflow,
+            rebuild=args.rebuild,
+            quiet=args.quiet,
         )
     elif args.mode == "dockerfiles":
         dockerfiles = tools.get_dockerfiles_from_paths(args.paths)

--- a/parallel_docker_build/cli.py
+++ b/parallel_docker_build/cli.py
@@ -22,6 +22,13 @@ def parse_cmd_line_args():
         action="store_true",
         help="Suppress stdout",
     )
+    parser.add_argument(
+        "-t",
+        "--tag",
+        type=str,
+        default="latest",
+        help="Custom tag",
+    )
     subparsers = parser.add_subparsers(
         title="mode", dest="mode", help="Mode of specifying a build."
     )
@@ -85,7 +92,9 @@ def parse_cmd_line_args():
 def main():
     args = parse_cmd_line_args()
     if args.mode == "workflow":
-        tools.run_workflow(args.workflow, rebuild=args.rebuild, quiet=args.quiet)
+        tools.run_workflow(
+            args.workflow, rebuild=args.rebuild, quiet=args.quiet, tag=args.tag
+        )
     elif args.mode == "dockerfiles":
         dockerfiles = tools.get_dockerfiles_from_paths(args.paths)
         tools.make_images(
@@ -97,6 +106,7 @@ def main():
             push=args.push,
             rebuild=args.rebuild,
             quiet=args.quiet,
+            tag=args.tag,
         )
     else:
         raise ValueError(f"Unknown mode: {args.mode}")

--- a/parallel_docker_build/cli.py
+++ b/parallel_docker_build/cli.py
@@ -22,13 +22,6 @@ def parse_cmd_line_args():
         action="store_true",
         help="Suppress stdout",
     )
-    parser.add_argument(
-        "-t",
-        "--tag",
-        type=str,
-        default="latest",
-        help="Custom tag",
-    )
     subparsers = parser.add_subparsers(
         title="mode", dest="mode", help="Mode of specifying a build."
     )
@@ -86,6 +79,13 @@ def parse_cmd_line_args():
             "Default is 1."
         ),
     )
+    dockerfiles_parser.add_argument(
+        "-t",
+        "--tag",
+        type=str,
+        default="latest",
+        help="Custom tag. Default is 'latest'",
+    )
     return parser.parse_args()
 
 
@@ -93,7 +93,7 @@ def main():
     args = parse_cmd_line_args()
     if args.mode == "workflow":
         tools.run_workflow(
-            args.workflow, rebuild=args.rebuild, quiet=args.quiet, tag=args.tag
+            args.workflow, rebuild=args.rebuild, quiet=args.quiet,
         )
     elif args.mode == "dockerfiles":
         dockerfiles = tools.get_dockerfiles_from_paths(args.paths)

--- a/parallel_docker_build/cli.py
+++ b/parallel_docker_build/cli.py
@@ -31,7 +31,7 @@ def parse_cmd_line_args():
     # Specify a yaml workflow
     workflow_parser.add_argument(
         "workflow",
-        type=str,
+        type=argparse.FileType("r"),
         help="Path to workflow yaml file image filenames(s).",
     )
 

--- a/parallel_docker_build/tools.py
+++ b/parallel_docker_build/tools.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import Iterable, Union, List, AnyStr
 import docker
 from docker.utils import kwargs_from_env
+import sys
 
 MAX_NUM_WORKERS = int(multiprocessing.cpu_count() // 2)
 WORKFLOW_SCHEMA_PATH = Path(__file__).parent / "workflow-schema.yaml"
@@ -259,7 +260,10 @@ def validate_workflow_yaml(workflow: Union[Path, dict]) -> dict:
     """
     # Load
     if isinstance(workflow, (Path, str)):
-        data = yamale.make_data(path=_absolute_file(workflow))
+        if workflow == "-":
+            data = yamale.make_data(content=sys.stdin.read())
+        else:
+            data = yamale.make_data(path=_absolute_file(workflow))
     elif isinstance(workflow, dict):
         data = yamale.make_data(content=yaml.dump(workflow))
     else:

--- a/parallel_docker_build/tools.py
+++ b/parallel_docker_build/tools.py
@@ -42,10 +42,6 @@ def get_high_level_docker_api():
     return docker.from_env()
 
 
-def get_low_level_docker_api():
-    return docker.APIClient()
-
-
 def parse_stream(out) -> List[AnyStr]:
     data = json.loads(out)
     if "error" in data:
@@ -72,7 +68,7 @@ def do_build(
     dockerfile = _absolute_file(dockerfile)
     context = _absolute_dir(context)
     do_print(f"Building {dockerfile} from context {context}", name=name, quiet=quiet)
-    api = get_low_level_docker_api()
+    api = get_high_level_docker_api()
     name = full_name if name is None else f"{name}|{full_name}"
     if not str(dockerfile).startswith(str(context)):
         raise FileNotFoundError(

--- a/parallel_docker_build/tools.py
+++ b/parallel_docker_build/tools.py
@@ -44,8 +44,7 @@ def get_high_level_docker_api():
 
 
 def get_low_level_docker_api():
-    kwargs = kwargs_from_env()
-    return docker.APIClient(**kwargs)
+    return docker.APIClient(**kwargs_from_env())
 
 
 def parse_stream(out) -> List[AnyStr]:

--- a/parallel_docker_build/tools.py
+++ b/parallel_docker_build/tools.py
@@ -291,7 +291,7 @@ def validate_workflow_yaml(workflow: Union[IO, dict, str]) -> dict:
 
 
 def run_workflow(
-    workflow: Path, rebuild: bool = False, quiet: bool = False, tag: str = "latest"
+    workflow: IO, rebuild: bool = False, quiet: bool = False, tag: str = "latest"
 ) -> None:
     do_print(f"Loading: {workflow}")
     data = validate_workflow_yaml(workflow)

--- a/parallel_docker_build/tools.py
+++ b/parallel_docker_build/tools.py
@@ -6,6 +6,7 @@ import yaml
 from pathlib import Path
 from typing import Iterable, Union, List, AnyStr
 import docker
+from docker.utils import kwargs_from_env
 
 MAX_NUM_WORKERS = int(multiprocessing.cpu_count() // 2)
 WORKFLOW_SCHEMA_PATH = Path(__file__).parent / "workflow-schema.yaml"
@@ -42,6 +43,11 @@ def get_high_level_docker_api():
     return docker.from_env()
 
 
+def get_low_level_docker_api():
+    kwargs = kwargs_from_env()
+    return docker.APIClient(**kwargs)
+
+
 def parse_stream(out) -> List[AnyStr]:
     data = json.loads(out)
     if "error" in data:
@@ -68,7 +74,7 @@ def do_build(
     dockerfile = _absolute_file(dockerfile)
     context = _absolute_dir(context)
     do_print(f"Building {dockerfile} from context {context}", name=name, quiet=quiet)
-    api = get_high_level_docker_api()
+    api = get_low_level_docker_api()
     name = full_name if name is None else f"{name}|{full_name}"
     if not str(dockerfile).startswith(str(context)):
         raise FileNotFoundError(

--- a/parallel_docker_build/tools.py
+++ b/parallel_docker_build/tools.py
@@ -284,6 +284,7 @@ def validate_workflow_yaml(workflow: Union[IO, dict, str]) -> dict:
     validated.setdefault("max_num_workers", 1)
     validated.setdefault("cross_platform", False)
     validated.setdefault("push", False)
+    validated.setdefault("tag", "latest")
     for stage in validated["stages"]:
         stage.setdefault("context", ".")
     return validated
@@ -307,6 +308,6 @@ def run_workflow(
             rebuild=rebuild,
             quiet=quiet,
             name=name,
-            tag=tag,
+            tag=data["tag"],
         )
     do_print(f"Workflow complete: {workflow}")

--- a/parallel_docker_build/tools.py
+++ b/parallel_docker_build/tools.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import Iterable, Union, List, AnyStr
 import docker
 from docker.utils import kwargs_from_env
+import sys
 
 MAX_NUM_WORKERS = int(multiprocessing.cpu_count() // 2)
 WORKFLOW_SCHEMA_PATH = Path(__file__).parent / "workflow-schema.yaml"
@@ -260,7 +261,10 @@ def validate_workflow_yaml(workflow: Union[Path, dict]) -> dict:
     """
     # Load
     if isinstance(workflow, (Path, str)):
-        data = yamale.make_data(path=_absolute_file(workflow))
+        if workflow == "-":
+            data = yamale.make_data(content=sys.stdin.read())
+        else:
+            data = yamale.make_data(path=_absolute_file(workflow))
     elif isinstance(workflow, dict):
         data = yamale.make_data(content=yaml.dump(workflow))
     else:

--- a/parallel_docker_build/tools.py
+++ b/parallel_docker_build/tools.py
@@ -4,7 +4,7 @@ import multiprocessing
 import yamale
 import yaml
 from pathlib import Path
-from typing import Iterable, Union, List, AnyStr
+from typing import Iterable, Union, List, AnyStr, IO
 import docker
 from docker.utils import kwargs_from_env
 import sys
@@ -246,13 +246,13 @@ def get_dockerfiles_from_paths(
     return dockerfiles
 
 
-def validate_workflow_yaml(workflow: Union[Path, dict]) -> dict:
+def validate_workflow_yaml(workflow: Union[IO, dict, str]) -> dict:
     """Validate workflow yaml file
 
     Parameters
     ----------
-    workflow : Union[Path, dict]
-        Workflow yaml path or loaded dictionary.
+    workflow : Union[IO, dict, str]
+        Workflow yaml file-object/stream, dictionary or string with yaml data.
 
     Returns
     -------
@@ -260,15 +260,13 @@ def validate_workflow_yaml(workflow: Union[Path, dict]) -> dict:
         Validated workflow
     """
     # Load
-    if isinstance(workflow, (Path, str)):
-        if workflow == "-":
-            data = yamale.make_data(content=sys.stdin.read())
-        else:
-            data = yamale.make_data(path=_absolute_file(workflow))
-    elif isinstance(workflow, dict):
-        data = yamale.make_data(content=yaml.dump(workflow))
+    if isinstance(workflow, dict):
+        content = yaml.dump(workflow)
+    elif hasattr(workflow, "read"):
+        content = workflow.read()
     else:
-        raise ValueError(f"The workflow is not supported: {workflow}")
+        content = workflow
+    data = yamale.make_data(content=content)
     schema = yamale.make_schema(WORKFLOW_SCHEMA_PATH)
     yamale.validate(schema, data)
     validated = data[0][0]
@@ -281,7 +279,7 @@ def validate_workflow_yaml(workflow: Union[Path, dict]) -> dict:
     return validated
 
 
-def run_workflow(workflow: Path, rebuild: bool = False, quiet: bool = False) -> None:
+def run_workflow(workflow: IO, rebuild: bool = False, quiet: bool = False) -> None:
     do_print(f"Loading: {workflow}")
     data = validate_workflow_yaml(workflow)
     for i, stage in enumerate(data["stages"]):

--- a/parallel_docker_build/tools.py
+++ b/parallel_docker_build/tools.py
@@ -283,6 +283,7 @@ def validate_workflow_yaml(workflow: Union[Path, dict]) -> dict:
     validated.setdefault("max_num_workers", 1)
     validated.setdefault("cross_platform", False)
     validated.setdefault("push", False)
+    validated.setdefault("tag", "latest")
     for stage in validated["stages"]:
         stage.setdefault("context", ".")
     return validated
@@ -306,6 +307,6 @@ def run_workflow(
             rebuild=rebuild,
             quiet=quiet,
             name=name,
-            tag=tag,
+            tag=data["tag"],
         )
     do_print(f"Workflow complete: {workflow}")

--- a/parallel_docker_build/tools.py
+++ b/parallel_docker_build/tools.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import Iterable, Union, List, AnyStr, IO
 import docker
 from docker.utils import kwargs_from_env
-import sys
+
 
 MAX_NUM_WORKERS = int(multiprocessing.cpu_count() // 2)
 WORKFLOW_SCHEMA_PATH = Path(__file__).parent / "workflow-schema.yaml"

--- a/parallel_docker_build/tools.py
+++ b/parallel_docker_build/tools.py
@@ -70,6 +70,7 @@ def do_build(
     rebuild: bool = False,
     quiet: bool = False,
     name: str = None,
+    tag: str = "latest",
 ) -> None:
     dockerfile = _absolute_file(dockerfile)
     context = _absolute_dir(context)
@@ -89,7 +90,7 @@ def do_build(
     options = {
         "path": str(context),
         "dockerfile": _dockerfile,
-        "tag": f"{full_name}:latest",
+        "tag": f"{full_name}:{tag}",
         "nocache": rebuild,
         "quiet": False,
     }
@@ -119,6 +120,7 @@ def make_image(
     rebuild: bool = False,
     quiet: bool = False,
     name: str = None,
+    tag: str = "latest",
 ) -> None:
     # Handle paths
     dockerfile = _absolute_file(dockerfile)
@@ -162,11 +164,17 @@ def make_image(
         full_name += "_" + "_".join(extra_tags)
     # Build it
     do_build(
-        dockerfile, full_name, context=context, rebuild=rebuild, quiet=quiet, name=name
+        dockerfile,
+        full_name,
+        context=context,
+        rebuild=rebuild,
+        quiet=quiet,
+        name=name,
+        tag=tag,
     )
     # Push it
     if push:
-        do_push(full_name, tags=["latest"], quiet=quiet, name=name)
+        do_push(full_name, tags=[tag], quiet=quiet, name=name)
 
 
 def make_images(
@@ -179,6 +187,7 @@ def make_images(
     rebuild: bool = False,
     quiet: bool = False,
     name: str = None,
+    tag: str = "latest",
 ) -> None:
     if len(dockerfiles) == 1 or max_num_workers == 1:
         for dockerfile in dockerfiles:
@@ -191,6 +200,7 @@ def make_images(
                 push=push,
                 quiet=quiet,
                 name=name,
+                tag=tag,
             )
     else:
         results = []
@@ -208,6 +218,7 @@ def make_images(
                             push=push,
                             quiet=quiet,
                             name=name,
+                            tag=tag,
                         ),
                     )
                 )
@@ -277,7 +288,9 @@ def validate_workflow_yaml(workflow: Union[Path, dict]) -> dict:
     return validated
 
 
-def run_workflow(workflow: Path, rebuild: bool = False, quiet: bool = False) -> None:
+def run_workflow(
+    workflow: Path, rebuild: bool = False, quiet: bool = False, tag: str = "latest"
+) -> None:
     do_print(f"Loading: {workflow}")
     data = validate_workflow_yaml(workflow)
     for i, stage in enumerate(data["stages"]):
@@ -293,5 +306,6 @@ def run_workflow(workflow: Path, rebuild: bool = False, quiet: bool = False) -> 
             rebuild=rebuild,
             quiet=quiet,
             name=name,
+            tag=tag,
         )
     do_print(f"Workflow complete: {workflow}")

--- a/parallel_docker_build/tools.py
+++ b/parallel_docker_build/tools.py
@@ -70,6 +70,7 @@ def do_build(
     rebuild: bool = False,
     quiet: bool = False,
     name: str = None,
+    tag: str = "latest",
 ) -> None:
     dockerfile = _absolute_file(dockerfile)
     context = _absolute_dir(context)
@@ -89,7 +90,7 @@ def do_build(
     options = {
         "path": str(context),
         "dockerfile": _dockerfile,
-        "tag": f"{full_name}:latest",
+        "tag": f"{full_name}:{tag}",
         "nocache": rebuild,
         "quiet": False,
     }
@@ -119,6 +120,7 @@ def make_image(
     rebuild: bool = False,
     quiet: bool = False,
     name: str = None,
+    tag: str = "latest",
 ) -> None:
     # Handle paths
     dockerfile = _absolute_file(dockerfile)
@@ -162,11 +164,17 @@ def make_image(
         full_name += "_" + "_".join(extra_tags)
     # Build it
     do_build(
-        dockerfile, full_name, context=context, rebuild=rebuild, quiet=quiet, name=name
+        dockerfile,
+        full_name,
+        context=context,
+        rebuild=rebuild,
+        quiet=quiet,
+        name=name,
+        tag=tag,
     )
     # Push it
     if push:
-        do_push(full_name, tags=["latest"], quiet=quiet, name=name)
+        do_push(full_name, tags=[tag], quiet=quiet, name=name)
 
 
 def make_images(
@@ -179,6 +187,7 @@ def make_images(
     rebuild: bool = False,
     quiet: bool = False,
     name: str = None,
+    tag: str = "latest",
 ) -> None:
     if len(dockerfiles) == 1 or max_num_workers == 1:
         for dockerfile in dockerfiles:
@@ -191,6 +200,7 @@ def make_images(
                 push=push,
                 quiet=quiet,
                 name=name,
+                tag=tag,
             )
     else:
         results = []
@@ -208,6 +218,7 @@ def make_images(
                             push=push,
                             quiet=quiet,
                             name=name,
+                            tag=tag,
                         ),
                     )
                 )
@@ -278,7 +289,9 @@ def validate_workflow_yaml(workflow: Union[IO, dict, str]) -> dict:
     return validated
 
 
-def run_workflow(workflow: IO, rebuild: bool = False, quiet: bool = False) -> None:
+def run_workflow(
+    workflow: IO, rebuild: bool = False, quiet: bool = False, tag: str = "latest"
+) -> None:
     do_print(f"Loading: {workflow}")
     data = validate_workflow_yaml(workflow)
     for i, stage in enumerate(data["stages"]):
@@ -294,5 +307,6 @@ def run_workflow(workflow: IO, rebuild: bool = False, quiet: bool = False) -> No
             rebuild=rebuild,
             quiet=quiet,
             name=name,
+            tag=tag,
         )
     do_print(f"Workflow complete: {workflow}")

--- a/parallel_docker_build/workflow-schema.yaml
+++ b/parallel_docker_build/workflow-schema.yaml
@@ -7,7 +7,7 @@ cross_platform: bool(required=False)
 # Push images to registry. Default: False
 push: bool(required=False)
 # Image tag. Default: "latest"
-tag: str()
+tag: str(required=False)
 # Workflow build stages
 stages: list(include('stage'), min=1)
 ---

--- a/parallel_docker_build/workflow-schema.yaml
+++ b/parallel_docker_build/workflow-schema.yaml
@@ -6,6 +6,8 @@ max_num_workers: int(min=1, required=False)
 cross_platform: bool(required=False)
 # Push images to registry. Default: False
 push: bool(required=False)
+# Image tag. Default: "latest"
+tag: str()
 # Workflow build stages
 stages: list(include('stage'), min=1)
 ---


### PR DESCRIPTION
Closes https://github.com/jccurtis/parallel-docker-build/issues/3

This will enable changing the tag. So far this was forced to be `latest`. Now it can be either defined in a `workflow.yaml` or over the command line api.

I first thought it should be defined only over the command line, but then realized that it isn't to hard to just change the yaml value with yq.
```bash
yq eval '.push=True | .tag="v1.0.0"' workflow.yaml | parallel-docker-build workflow -
```
Obiously that solutions depends on https://github.com/jccurtis/parallel-docker-build/pull/4